### PR TITLE
Add gulp to npm scripts & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 To update the compiled version of the package under `dist/`, run:
 ```
-$ gulp build
+$ npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git@github.com:genialis/resolwe-js.git"
   },
+  "scripts": {
+    "build": "gulp build"
+  },
   "main": "dist/index.js",
   "typings": "dist/index",
   "devDependencies": {


### PR DESCRIPTION
After a chat with @hadalin I wanted to check out `resolwe-js`, but I couldn't build it using the instructions on the readme (as I do not have gulp installed globally).

I updated the project locally so I could build it using the local `gulp` package. I guess comparable to what this [PR](https://github.com/genialis/resolwe-js/pull/9) is doing. 

Feel free to merge or close this PR if this isn't what you are looking for, I just thought I could drop in the PR as I've updated it for me to build the project anyway.