### PR TITLE
Fix unit tests and support `limit` in kb autocomplete

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,16 @@ Added
 
 Changed
 -------
+
+Fixed
+-----
+
+==================
+3.1.0 - 2018-02-26
+==================
+
+Changed
+-------
 - Support paginated Feature.autocomplete in knowledge base module
 
 Fixed

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 
 Fixed
 -----
+- Fixed missing Rx import in mocked upload
 
 ==================
 3.0.0 - 2018-01-24

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 
 Changed
 -------
+- Support paginated Feature.autocomplete in knowledge base module
 
 Fixed
 -----

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@genialis/resolwe",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@genialis/resolwe",
   "author": "Genialis Inc.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Resolwe frontend libraries",
   "license" : "Apache-2.0",
   "repository": {

--- a/src/core/services/api.spec.ts
+++ b/src/core/services/api.spec.ts
@@ -166,7 +166,7 @@ describeComponent('angular mock api', [], (tester) => {
         });
 
         tester.api().upload({}, 'test-uuid').subscribe((response) => {
-            expect(response.type).toEqual('result');
+            expect(response.type).toEqual(UploadEventType.RESULT);
             if (response.type === UploadEventType.RESULT) {
                 expect(uploaded).toEqual(true);
                 expect(response.result).toEqual({ data: 'hello' });
@@ -238,7 +238,7 @@ describe('upload', () => {
         );
 
         api.uploadString('a.txt', 'abcd').subscribe((response) => {
-            expect(response.type).toEqual('result');
+            expect(response.type).toEqual(UploadEventType.RESULT);
             if (response.type === UploadEventType.RESULT) {
                 expect(response.result.files[0].name).toEqual('a.txt');
                 expect($exceptionHandler.errors).toEqual([]);
@@ -258,9 +258,9 @@ describe('upload', () => {
 
         const largeContent = _.range(3 * api.CHUNK_SIZE - 1).map(() => 'a').join('');
         api.uploadString('a.txt', largeContent).toArray().subscribe(([response1, response2, response3]) => {
-            expect(response1.type).toEqual('progress');
-            expect(response2.type).toEqual('progress');
-            expect(response3.type).toEqual('result');
+            expect(response1.type).toEqual(UploadEventType.PROGRESS);
+            expect(response2.type).toEqual(UploadEventType.PROGRESS);
+            expect(response3.type).toEqual(UploadEventType.RESULT);
             expect($exceptionHandler.errors).toEqual([]);
             done();
         });
@@ -276,8 +276,8 @@ describe('upload', () => {
 
         const largeContent = _.range(3 * api.CHUNK_SIZE - 1).map(() => 'a').join('');
         api.uploadString('a.txt', largeContent).toArray().subscribe(([response1, response2]) => {
-            expect(response1.type).toEqual('progress');
-            expect(response2.type).toEqual('result');
+            expect(response1.type).toEqual(UploadEventType.PROGRESS);
+            expect(response2.type).toEqual(UploadEventType.RESULT);
             expect($exceptionHandler.errors).toEqual([]);
             done();
         });
@@ -291,11 +291,11 @@ describe('upload', () => {
 
         const largeContent = _.range(3 * api.CHUNK_SIZE - 1).map(() => 'a').join('');
         api.uploadString('a.txt', largeContent).toArray().subscribe((responses) => {
-            expect(responses[0].type).toEqual('retrying');
-            expect(responses[1].type).toEqual('retrying');
-            expect(responses[2].type).toEqual('progress');
-            expect(responses[3].type).toEqual('retrying');
-            expect(responses[4].type).toEqual('result');
+            expect(responses[0].type).toEqual(UploadEventType.RETRYING);
+            expect(responses[1].type).toEqual(UploadEventType.RETRYING);
+            expect(responses[2].type).toEqual(UploadEventType.PROGRESS);
+            expect(responses[3].type).toEqual(UploadEventType.RETRYING);
+            expect(responses[4].type).toEqual(UploadEventType.RESULT);
 
             const unexpectedLogs = $exceptionHandler.errors.filter((log) => {
                 const isExpected = _.isString(log) && /Possibly unhandled rejection: .*"status":503/.test(log);

--- a/src/tests/mock.ts
+++ b/src/tests/mock.ts
@@ -1,3 +1,4 @@
+import * as Rx from 'rx';
 import {UploadEvent, UploadEventType} from '../core/services/api';
 import 'ng-file-upload';
 


### PR DESCRIPTION
Description:
- Somehow, unit tests passed in https://github.com/genialis/resolwe-js/pull/59 (despite missing Rx import) but the same thing failed when an external repository imported it
- `api.KnowledgeBase.Feature.autocomplete` didn't support `limit`, only getting all results