### PR TITLE
 Fix disposing resource subscriptions before QueryObserver is initialized

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-----
+- Fixed disposing subscriptions to a reactive query after another subscription disposes
+  before QueryObserver is initialized
+
 ==================
 5.0.0 - 2018-08-03
 ==================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+
+==================
+5.0.1 - 2018-08-14
+==================
+
 Fixed
 -----
 - Fixed disposing subscriptions to a reactive query after another subscription disposes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@genialis/resolwe",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@genialis/resolwe",
   "author": "Genialis Inc.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Resolwe frontend libraries",
   "license": "Apache-2.0",
   "repository": {

--- a/src/api/resource.spec.ts
+++ b/src/api/resource.spec.ts
@@ -81,6 +81,17 @@ describeComponent('reactive queries', [], () => {
             }, 100);
         });
 
+        it('after a subscription is disposed before QueryObserver is INITIALIZED', (done) => {
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+            setTimeout(() => {
+                // QueryObserver is initialized.
+                expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+                done();
+            }, 100);
+        });
+
         // tslint:disable-next-line:max-line-length
         it('after disposing a subscription that was made after another subscription is disposed before QueryObserver is INITIALIZED', (done) => {
             mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
@@ -95,6 +106,26 @@ describeComponent('reactive queries', [], () => {
                 expect(unsubscribeRequestedSpy).toHaveBeenCalled();
 
                 done();
+            }, 100);
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it('after disposing a subscription that was made after QueryObserver is INITIALIZED after another subscription is disposed before QueryObserver is INITIALIZED', (done) => {
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+            setTimeout(() => {
+                // QueryObserver is initialized.
+                expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+                unsubscribeRequestedSpy.calls.reset();
+
+                const subscription3 = mockApi.Data.query({}, {reactive: true}).subscribe();
+                setTimeout(() => {
+                    expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+                    subscription3.dispose();
+                    expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+                    done();
+                }, 100);
             }, 100);
         });
     });

--- a/src/api/resource.spec.ts
+++ b/src/api/resource.spec.ts
@@ -61,5 +61,41 @@ describeComponent('reactive queries', [], () => {
                 done();
             }, 100);
         });
+
+        it('after disposing all subscriptions', (done) => {
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            const subscription1 = mockApi.Data.query({}, {reactive: true}).subscribe();
+            const subscription2 = mockApi.Data.query({}, {reactive: true}).subscribe();
+
+            setTimeout(() => {
+                // QueryObserver is initialized.
+                expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+
+                subscription1.dispose();
+                expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+
+                subscription2.dispose();
+                expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+
+                done();
+            }, 100);
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it('after disposing a subscription that was made after another subscription is disposed before QueryObserver is INITIALIZED', (done) => {
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            mockApi.Data.query({}, {reactive: true}).subscribe().dispose();
+            const subscription3 = mockApi.Data.query({}, {reactive: true}).subscribe();
+
+            setTimeout(() => {
+                // QueryObserver is initialized.
+                expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+
+                subscription3.dispose();
+                expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+
+                done();
+            }, 100);
+        });
     });
 });

--- a/src/api/resource.spec.ts
+++ b/src/api/resource.spec.ts
@@ -1,0 +1,65 @@
+import {MockApi} from './mock';
+import {describeComponent} from '../tests/component';
+
+describeComponent('reactive queries', [], () => {
+    let mockApi: MockApi;
+    let unsubscribeRequestedSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        mockApi = new MockApi();
+        unsubscribeRequestedSpy = jasmine.createSpy('unsubscribeRequestedSpy');
+        mockApi.whenPost('/api/queryobserver/unsubscribe', unsubscribeRequestedSpy);
+
+        mockApi.createResource('data');
+        mockApi.simulateDelay(true);
+    });
+
+    it('should be disposable', (done) => {
+        const subscriber1 = jasmine.createSpy('subscriber1');
+        const subscriber2 = jasmine.createSpy('subscriber2');
+        const subscriber3 = jasmine.createSpy('subscriber3');
+
+        mockApi.Data.query({}, {reactive: true}).subscribe(subscriber1).dispose();
+        mockApi.Data.query({}, {reactive: true}).subscribe(subscriber2).dispose();
+        const subscription3 = mockApi.Data.query({}, {reactive: true}).subscribe(subscriber3);
+
+        // Ensure these queries have been delayed.
+        expect(subscriber1).not.toHaveBeenCalled();
+        expect(subscriber2).not.toHaveBeenCalled();
+        expect(subscriber3).not.toHaveBeenCalled();
+
+        setTimeout(() => {
+            expect(subscriber1).not.toHaveBeenCalled();
+            expect(subscriber2).not.toHaveBeenCalled();
+            expect(subscriber3).toHaveBeenCalledTimes(1);
+
+            mockApi.addItem('data', {id: 1});
+            expect(subscriber1).not.toHaveBeenCalled();
+            expect(subscriber2).not.toHaveBeenCalled();
+            expect(subscriber3).toHaveBeenCalledTimes(2);
+
+            subscription3.dispose();
+
+            mockApi.addItem('data', {id: 1});
+            expect(subscriber3).toHaveBeenCalledTimes(2);
+
+            done();
+        }, 100);
+    });
+
+    describe('should make unsubscribe request', () => {
+        it('after disposing the subscription', (done) => {
+            const subscription1 = mockApi.Data.query({}, {reactive: true}).subscribe();
+
+            setTimeout(() => {
+                // QueryObserver is initialized.
+                expect(unsubscribeRequestedSpy).not.toHaveBeenCalled();
+
+                subscription1.dispose();
+                expect(unsubscribeRequestedSpy).toHaveBeenCalled();
+
+                done();
+            }, 100);
+        });
+    });
+});

--- a/src/api/resource.ts
+++ b/src/api/resource.ts
@@ -163,6 +163,14 @@ export abstract class Resource {
                 for (const subscription of subscriptions) {
                     subscription.dispose();
                 }
+
+                // If query is still just pending, remove observer before it even becomes disposable.
+                if (this._pendingQueries[serializedQuery]) {
+                    this._pendingQueries[serializedQuery] = _.reject(this._pendingQueries[serializedQuery], (pending) => {
+                        // Check for same reference, not content!
+                        return pending.subscriptions === subscriptions;
+                    });
+                }
             };
         }).publish().refCount();
     }


### PR DESCRIPTION
There was a bug in unsubscribing from reactive queries.

This correctly made a request to /api/queryobserver/unsubscribe:
```ts
const c = api.Sample.queryAnnotated({limit: 1}, {reactive: true}).subscribe();
setTimeout(() => {
    c.dispose();
}, 2000);
```

but this didn't make a request to /api/queryobserver/unsubscribe:
```ts
api.Sample.queryAnnotated({limit: 1}, {reactive: true}).subscribe().dispose();
api.Sample.queryAnnotated({limit: 1}, {reactive: true}).subscribe().dispose();

const c = api.Sample.queryAnnotated({limit: 1}, {reactive: true}).subscribe();
setTimeout(() => {
    c.dispose();
}, 2000);
```